### PR TITLE
Add more tools.

### DIFF
--- a/13_ubuntu-22.04_broadway/Dockerfile
+++ b/13_ubuntu-22.04_broadway/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
       x11proto-core-dev libx11-dev lib32z1-dev libgl1-mesa-dev libxml2-utils xsltproc unzip fontconfig \
       repo openssh-client \
       meson dosfstools mtools e2fsprogs \
+      pkg-config python3-mako python3-jinja2 python3-ply python3-yaml \
  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER user

--- a/13_ubuntu-22.04_xpra/Dockerfile
+++ b/13_ubuntu-22.04_xpra/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update \
       x11proto-core-dev libx11-dev lib32z1-dev libgl1-mesa-dev libxml2-utils xsltproc unzip fontconfig \
       repo openssh-client \
       meson dosfstools mtools e2fsprogs \
+      pkg-config python3-mako python3-jinja2 python3-ply python3-yaml \
  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER user


### PR DESCRIPTION
They are required by `dav1d`. `dav1d` is used in AAOS for RPi.

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
