### PR TITLE
Add psmisc for pstree.

### DIFF
--- a/13_ubuntu-22.04_broadway/Dockerfile
+++ b/13_ubuntu-22.04_broadway/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
       meson dosfstools mtools e2fsprogs \
       fdisk kpartx \
       pkg-config python3-mako python3-jinja2 python3-ply python3-yaml \
+      psmisc \
  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER user

--- a/13_ubuntu-22.04_xpra/Dockerfile
+++ b/13_ubuntu-22.04_xpra/Dockerfile
@@ -10,6 +10,7 @@ RUN apt-get update \
       meson dosfstools mtools e2fsprogs \
       fdisk kpartx \
       pkg-config python3-mako python3-jinja2 python3-ply python3-yaml \
+      psmisc \
  && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
  && apt-get clean && rm -rf /var/lib/apt/lists/*
 USER user


### PR DESCRIPTION
As recent versions of Ninja calls `pstree` implicitly.

see also: https://android.googlesource.com/platform/build/soong/+/refs/heads/android14-release/ui/build/ninja.go#316

Signed-off-by: Masaki Muranaka <monaka@monami-ya.com>
